### PR TITLE
ArrayELResolver.setValue should take autoboxing into account

### DIFF
--- a/src/main/java/javax/el/ArrayELResolver.java
+++ b/src/main/java/javax/el/ArrayELResolver.java
@@ -58,10 +58,9 @@
 
 package javax.el;
 
-import java.lang.reflect.Array;
-import java.util.List;
-import java.util.Iterator;
 import java.beans.FeatureDescriptor;
+import java.lang.reflect.Array;
+import java.util.Iterator;
 
 /**
  * Defines property resolution behavior on arrays.
@@ -256,8 +255,10 @@ public class ArrayELResolver extends ELResolver {
                 throw new PropertyNotWritableException();
             }
             Class<?> type = base.getClass().getComponentType();
-            if (val != null && ! type.isAssignableFrom(val.getClass())) {
-                throw new ClassCastException();
+            if (val != null && !Util.isAssignableFrom(val.getClass(), type)) {
+                throw new ClassCastException(Util.message(context,
+                        "objectNotAssignable", val.getClass().getName(),
+                        type.getName()));
             }
             int index = toInteger (property);
             if (index < 0 || index >= Array.getLength(base)) {


### PR DESCRIPTION
`ArrayELResolver.setValue` takes an object as input value, yet the target may be a primitive array. Autoboxing possibilities should be considered before throwing a `ClassCastException`.

The available method in the `Util` class is is used to resolve this.

See also [the corresponding report in the ASF Bugzilla](https://issues.apache.org/bugzilla/show_bug.cgi?id=55691).
