### PR TITLE
Find valid properties outside from JavaBeans standard

### DIFF
--- a/src/main/java/javax/el/BeanELResolver.java
+++ b/src/main/java/javax/el/BeanELResolver.java
@@ -214,8 +214,7 @@ public class BeanELResolver extends ELResolver {
      */
     final static class BeanProperties {
 
-        private final Map<String, BeanProperty> propertyMap =
-            new HashMap<String, BeanProperty>();
+        private final Map<String, BeanProperty> propertyMap = new HashMap<String, BeanProperty>();
                                                                                 
         public BeanProperties(Class<?> baseClass) {
             PropertyDescriptor[] descriptors;
@@ -226,8 +225,13 @@ public class BeanELResolver extends ELResolver {
                 throw new ELException(ie);
             }
             for (PropertyDescriptor pd: descriptors) {
-                propertyMap.put(pd.getName(),
-                                new BeanProperty(baseClass, pd));
+                propertyMap.put(pd.getName(), new BeanProperty(baseClass, pd));
+            }
+            
+            for (PropertyDescriptor pd : Util.findPropertiesOutsideFromJavaBeansStandard(baseClass)) {
+            	if (!propertyMap.containsKey(pd.getName())) {
+            		propertyMap.put(pd.getName(), new BeanProperty(baseClass, pd));
+            	}
             }
         }
                                                                                 


### PR DESCRIPTION
When I have to use Scala language always I have problem with JSP to access my attributes.

The problem is simple, Scala there is not the convention of methods getters / setters to encapsulation of attributes, this is embedded in language.

To maintain compatibility, Scala has "scala.beans.BeanProperty" annotation to generate accessor methods in Java style. The template engine Velocity offers support to call method without JavaBeans standard.

To solve this issue on the side of the EL, I have added support for finding methods created for Scala.

I have created this project https://github.com/aparra/sample-vraptor4-scala to validate the idea.
