### PR TITLE
Use the correct class loader when attempting to resolve constants

### DIFF
--- a/src/main/java/javax/el/ImportHandler.java
+++ b/src/main/java/javax/el/ImportHandler.java
@@ -173,7 +173,7 @@ public class ImportHandler {
     private Class<?> getClassFor(String className) {
         if (!notAClass.contains(className)) {
             try {
-                return Class.forName(className, false, getClass().getClassLoader());
+                return Class.forName(className, false, Thread.currentThread().getContextClassLoader());
             } catch (ClassNotFoundException ex) {
                 notAClass.add(className);
             }


### PR DESCRIPTION
This fix already appears to be in the upstream RI implementation. I'm not sure how we normally import changes. This however would be required for https://github.com/wildfly/wildfly/pull/9114/ to work properly.
