### PR TITLE
Fix for JBEE-172: Unable to find unambiguous method: class java.lang.String.replace(java.lang.String, java.lang.String)

### DIFF
--- a/src/main/java/javax/el/Util.java
+++ b/src/main/java/javax/el/Util.java
@@ -217,7 +217,7 @@ class Util {
     private static Wrapper findWrapper(Class<?> clazz, List<Wrapper> wrappers,
             String name, Class<?>[] paramTypes, Object[] paramValues) {
 
-        Map<Wrapper,Integer> candidates = new HashMap<>();
+        Map<Wrapper,MatchResult> candidates = new HashMap<>();
 
         int paramCount;
         if (paramTypes == null) {
@@ -244,6 +244,8 @@ class Util {
 
             // Check the parameters match
             int exactMatch = 0;
+            int assignableMatch = 0;
+            int coercibleMatch = 0;
             boolean noMatch = false;
             for (int i = 0; i < mParamCount; i++) {
                 // Can't be null
@@ -252,12 +254,16 @@ class Util {
                 } else if (i == (mParamCount - 1) && w.isVarArgs()) {
                     Class<?> varType = mParamTypes[i].getComponentType();
                     for (int j = i; j < paramCount; j++) {
-                        if (!isAssignableFrom(paramTypes[j], varType)) {
+                        if (isAssignableFrom(paramTypes[j], varType)) {
+                    	    assignableMatch++;
+                        } else {
                             if (paramValues == null) {
                                 noMatch = true;
                                 break;
                             } else {
-                                if (!isCoercibleFrom(paramValues[j], varType)) {
+                                if (isCoercibleFrom(paramValues[j], varType)) {
+                            	    coercibleMatch++;
+                                } else {
                                     noMatch = true;
                                     break;
                                 }
@@ -267,12 +273,16 @@ class Util {
                         // lead to a varArgs method matching when the result
                         // should be ambiguous
                     }
-                } else if (!isAssignableFrom(paramTypes[i], mParamTypes[i])) {
+                } else if (isAssignableFrom(paramTypes[i], mParamTypes[i])) {
+                    assignableMatch++;
+                } else {
                     if (paramValues == null) {
                         noMatch = true;
                         break;
                     } else {
-                        if (!isCoercibleFrom(paramValues[i], mParamTypes[i])) {
+                        if (isCoercibleFrom(paramValues[i], mParamTypes[i])) {
+                            coercibleMatch++;
+                        } else {
                             noMatch = true;
                             break;
                         }
@@ -289,26 +299,26 @@ class Util {
                 return w;
             }
 
-            candidates.put(w, Integer.valueOf(exactMatch));
+            candidates.put(w, new MatchResult(exactMatch, assignableMatch, coercibleMatch));
         }
 
         // Look for the method that has the highest number of parameters where
         // the type matches exactly
-        int bestMatch = 0;
+        MatchResult bestMatch = new MatchResult(0, 0, 0);
         Wrapper match = null;
         boolean multiple = false;
-        for (Map.Entry<Wrapper, Integer> entry : candidates.entrySet()) {
-            if (entry.getValue().intValue() > bestMatch ||
-                    match == null) {
-                bestMatch = entry.getValue().intValue();
+        for (Map.Entry<Wrapper, MatchResult> entry : candidates.entrySet()) {
+            int cmp = entry.getValue().compareTo(bestMatch);
+            if (cmp > 0 || match == null) {
+                bestMatch = entry.getValue();
                 match = entry.getKey();
                 multiple = false;
-            } else if (entry.getValue().intValue() == bestMatch) {
+            } else if (cmp == 0) {
                 multiple = true;
             }
         }
         if (multiple) {
-            if (bestMatch == paramCount - 1) {
+            if (bestMatch.getExact() == paramCount - 1) {
                 // Only one parameter is not an exact match - try using the
                 // super class
                 match = resolveAmbiguousWrapper(candidates.keySet(), paramTypes);
@@ -709,6 +719,58 @@ class Util {
         @Override
         public boolean isVarArgs() {
             return c.isVarArgs();
+        }
+    }
+    
+    /*
+     * This class duplicates code in org.apache.el.util.ReflectionUtil. When
+     * making changes keep the code in sync.
+     */
+    private static class MatchResult implements Comparable<MatchResult> {
+
+        private final int exact;
+        private final int assignable;
+        private final int coercible;
+
+        public MatchResult(int exact, int assignable, int coercible) {
+            this.exact = exact;
+            this.assignable = assignable;
+            this.coercible = coercible;
+        }
+
+        public int getExact() {
+            return exact;
+        }
+
+        public int getAssignable() {
+            return assignable;
+        }
+
+        public int getCoercible() {
+            return coercible;
+        }
+
+        @Override
+        public int compareTo(MatchResult o) {
+            if (this.getExact() < o.getExact()) {
+                return -1;
+            } else if (this.getExact() > o.getExact()) {
+                return 1;
+            } else {
+                if (this.getAssignable() < o.getAssignable()) {
+                    return -1;
+                } else if (this.getAssignable() > o.getAssignable()) {
+                    return 1;
+                } else {
+                    if (this.getCoercible() < o.getCoercible()) {
+                        return -1;
+                    } else if (this.getCoercible() > o.getCoercible()) {
+                        return 1;
+                    } else {
+                        return 0;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/test/java/javax/el/BeanELResolverTestCase.java
+++ b/src/test/java/javax/el/BeanELResolverTestCase.java
@@ -63,4 +63,29 @@ public class BeanELResolverTestCase {
         final String result = (String) resolver.invoke(context, base, method, paramTypes, params);
         assertEquals("Hello prefix: [testVarArgs2]", result);
     }
+    
+    /**
+     * original test from the bugfix
+    */
+    @Test
+    public void testBug56425() {
+        ELProcessor processor = new ELProcessor();
+        processor.defineBean("string", "a-b-c-d");
+        assertEquals("a_b_c_d", processor.eval("string.replace(\"-\",\"_\")"));
+    }
+    
+    /**
+     * test the bugfix following the pattern of other tests
+     */
+    @Test
+    public void testBug56425_2() {
+        final BeanELResolver resolver = new BeanELResolver();
+        final ELContext context = new StandardELContext(ExpressionFactory.newInstance());
+        final String base = "a-b-c-d";
+        final String method = "replace";
+        final Class[] paramTypes = new Class[] { String.class, String.class };
+        final Object[] params = new Object[] { "-", "_" };
+        final String result = (String) resolver.invoke(context, base, method, paramTypes, params);
+        assertEquals("a_b_c_d", result);
+	}
 }


### PR DESCRIPTION
Hi, 

After some search I found that the fix for [JBEE-172](https://issues.jboss.org/browse/JBEE-172) was already done on Tomcat 7:
* bug [56425](https://bz.apache.org/bugzilla/show_bug.cgi?id=56425)
* commit [66642e9ca0674b13843b72e202593e3e58fc2894](https://github.com/apache/tomcat/commit/66642e9ca0674b13843b72e202593e3e58fc2894) 

As the code base has changed a bit I took the changes of the above commit and applied to JBoss EL API Spec too.

I validated the fix on WildFly 9.0.2.Final + JSF 1.2.

I'm requesting this merge because I believe this fix is worth for the new releases as well.

Thanks in advance.
